### PR TITLE
Scroll bug fixed

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { 
+    argTypesRegex: "^on[A-Z].*",
+  },
 }

--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -8,7 +8,7 @@ import Plugin from './assets/plugin.svg';
 import Repo from './assets/repo.svg';
 import StackAlt from './assets/stackalt.svg';
 
-<Meta title="Example/Introduction" />
+<Meta title="Example/Introduction" inline={true} argTypes={{ onload: { action: window.scrollTo(top) } }}/>
 
 <style>{`
   .subheading {

--- a/stories/Introduction.stories.mdx
+++ b/stories/Introduction.stories.mdx
@@ -8,7 +8,7 @@ import Plugin from './assets/plugin.svg';
 import Repo from './assets/repo.svg';
 import StackAlt from './assets/stackalt.svg';
 
-<Meta title="Example/Introduction" inline={true} argTypes={{ onload: { action: window.scrollTo(top) } }}/>
+<Meta title="Example/Introduction" argTypes={{ onload: { action: window.scrollTo(top) } }}/>
 
 <style>{`
   .subheading {

--- a/stories/long-doc-one.stories.mdx
+++ b/stories/long-doc-one.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title='Scroll Bug/Doc One' />
+<Meta title='Scroll Bug/Doc One' argTypes={{ onload: { action: window.scrollTo(top) } }}/>
 
 # Storybook MDX Scroll Position Bug
 

--- a/stories/long-doc-two.stories.mdx
+++ b/stories/long-doc-two.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title='Scroll Bug/Doc Two' />
+<Meta title='Scroll Bug/Doc Two' argTypes={{ onload: { action: window.scrollTo(top) } }}/>
 
 # Storybook MDX Scroll Position Bug
 


### PR DESCRIPTION
The scrolling bug as described in issue [#12497](https://github.com/storybookjs/storybook/issues/12497) is fixed for the latest version of storybook. 

The most probable region for this feature not working seems to be the default iframe rendering of stories. But still, everything in storybook is user-controlled and its documentation list various methods to provide more control over its UI through addons.

The above conclusion of iframe being the reason for abnormal behavior of scrollbar was based on the observing its behavior on switching between canvas and docs rendering of stories. 
When you are in docs mode and switch back to Example/Introduction tab it automatically scroll back to top. But for the other two tabs, it wasn't. It was fixed after importing Meta from addon-docs.

But the scrolling issue was fixed for docs only. To fix it for canvas as well, Action addon came to the rescue. It basically allows us to manually handle the events happening in the stories. I used action argsType annotation for handling the scrolling event. Here we declare an onload event which calls the basic scroll reset command.

```javascript
argTypes={{ onload: { action: window.scrollTo(top) } }}
```

Hope it helps. Let me know if any query is there and I would love some feedback and improvement. Thanks!